### PR TITLE
ci: add minimal GitHub Actions test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: Tests
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Run tests (Maven)
+        run: |
+          if [ -f mvnw ]; then chmod +x mvnw && ./mvnw -B test; else mvn -B test; fi


### PR DESCRIPTION
## Summary
Adds a minimal GitHub Actions workflow to run tests for this repository.

- Detected stack: **java**
- Workflow path: 
- Conservative defaults only; no runtime code changes.

## Why
This repository did not have a GitHub Actions workflow that runs tests.

## Notes
- Triggered on push to / and pull requests.
- Kept intentionally minimal and non-breaking.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a minimal GitHub Actions workflow to run Maven tests for this Java repo. It runs on pushes to main/master and on pull requests, uses Temurin Java 17 on ubuntu-latest, and uses mvnw if present (falls back to mvn).

<sup>Written for commit fe1275ed15fb8ef2695380044dfa8b4bfef7c8a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated testing infrastructure to validate code changes on repository updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->